### PR TITLE
Feat: include irma-frontend's frontend request for pairing codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "author": "Privacy by Design Foundation",
   "license": "BSD-3-Clause",
   "dependencies": {
-    "@privacybydesign/irma-frontend": "^0.3.3",
+    "@privacybydesign/irma-frontend": "^0.4.3",
     "bootstrap": "^4.3.1",
     "jquery": "^3.5.1"
   }

--- a/src/common.js
+++ b/src/common.js
@@ -211,13 +211,14 @@ function finishIDealTransaction() {
         },
     }).done(function(response) {
         setStatus('info', MESSAGES['issuing-ideal-credential']);
-        console.log('issuing session pointer:', response.sessionPointer);
+        console.log('issuing session pointer:', response.sessionPtr);
         irma.newPopup({
             language: MESSAGES['lang'],
             session: {
                 start: false,
                 mapping: {
-                    sessionPtr: () => response.sessionPointer,
+                    sessionPtr: () => response.sessionPtr,
+                    frontendRequest: () => response.frontendRequest,
                 },
                 result: false,
             },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@privacybydesign/irma-frontend@^0.3.3":
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/@privacybydesign/irma-frontend/-/irma-frontend-0.3.3.tgz#3485d4529dee10cfadab671591109f65fca8dc22"
-  integrity sha512-B/YlMxeZ7y69gd7swCxCp+Dv2l00MmiJHsMwjesevVqqOnYMUbvjjupI36doPoRe+GQsZpAxMdPtWVvdq6FfkQ==
+"@privacybydesign/irma-frontend@^0.4.3":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@privacybydesign/irma-frontend/-/irma-frontend-0.4.3.tgz#5d1389ecc9d3e08bef175756830f934f460de484"
+  integrity sha512-1UFNUI4cqAYXFndgcywckgEZKYqtz/eTXmH83gFNYkeBQzv8PKygowrrSOFlb5HUWaXCNnMeTTxVnZH4eLy9EQ==
 
 bootstrap@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
Start using irma-frontend to make sure pairing codes are requested when scanning a QR on issuance.

### Testing
I already deployed it here for testing: https://staging.privacybydesign.foundation/uitgifte/ideal/